### PR TITLE
Science pack 6 - replace coal with charcoal when SeaBlock mod is used

### DIFF
--- a/MoreSciencePacks-for1_1/data-final-fixes.lua
+++ b/MoreSciencePacks-for1_1/data-final-fixes.lua
@@ -162,6 +162,7 @@ if mods["SeaBlock"] then
     -- science pack 6:
     morescience.tech.add_recipe_unlock("advanced-material-processing", "more-science-pack-6")
     data.raw.recipe["more-science-pack-6"].hidden = false;
+    bobmods.lib.recipe.replace_ingredient("more-science-pack-6", "coal", "wood-charcoal")
 
     -- science pack 13 and its ingredients:
     morescience.tech.add_recipe_unlock("flammables", "more-science-pack-13")


### PR DESCRIPTION
Because no coal in SeaBlock :/