### PR TITLE
Fix usage of 'moresciencepack-no-lab-slots' setting

### DIFF
--- a/MoreSciencePacks-for1_1/data-updates.lua
+++ b/MoreSciencePacks-for1_1/data-updates.lua
@@ -41,8 +41,8 @@ require("prototypes.technology.technology-modded")
 	local blacklistLabs ={"creative-mode-fix_creative-lab", "lab-module"}
 
 	
-	
-	if mods["MomoTweak"] and mods["angelspetrochem"] and settings.startup["moresciencepack-no-lab-slots"].value == true and settings.startup["moresciencepack-GameProgressionFix"].value == true then 
+
+	if (mods["MomoTweak"] or mods["MomosTweak"]) and mods["angelspetrochem"] and settings.startup["moresciencepack-no-lab-slots"].value == true and settings.startup["moresciencepack-GameProgressionFix"].value == true then
 	--if all above = true, skip addition of packs to science labs.
 			--[[ IF all the above ascertions are true, prevent addition of msp packs as lab tools. packs will act as intermediates only in this configuration. 
 			This feature added for players who don't want the logistic hassle of inserting 37 science packs into labs, but are okay with very complex science crafting recipes. 

--- a/MoreSciencePacks-for1_1/locale/en/en.cfg
+++ b/MoreSciencePacks-for1_1/locale/en/en.cfg
@@ -151,7 +151,7 @@ moresciencepack-GameProgressionFix=Will remove All MSP packs from technology cos
 
 moresciencepack-unlock-all-packs=Begin the game with the recipes for all 30 MSP science packs enabled without requiring any research to make the packs. This does not extend to the ingredients required to craft the packs, so they won't be able to be crafted until you obtain the necessary ingredients, but this is another method for resolving cyclic-dependency conflicts caused by other mods. Options are nice.
 
-moresciencepack-no-lab-slots=Use with "Remove packs from research cost (Game Progression Fix)" as well as MomoTweak mod to treat MSP's 30 Packs as Intermediate crafting ingredients for vanilla packs only. Removes slots from labs, and slightly simplifies logistic headache....at a cost of even more complex crafting. DO NOT TOGGLE THIS during a game with active labs or labs containing MSP packs.
+moresciencepack-no-lab-slots=To use it check "Remove packs from research cost (Game Progression Fix)" setting and also make sure you use MomosTweak mod. Then MSP's 30 Packs will be treated as Intermediate crafting ingredients for vanilla science packs only. Removes slots from labs, and slightly simplifies logistic headache....at a cost of even more complex crafting. DO NOT TOGGLE THIS during a game with active labs or labs containing MSP packs.
 
 moresciencepack-IncreasedModuleCost=Adds MSP packs to the cost of module research (not yet implemented)
 moresciencepack-multiplier=Multiply result_count for ALL MSP packs by this value (1-100). Ignored if omniLib is enabled.

--- a/MoreSciencePacks-for1_1/locale/en/en.cfg
+++ b/MoreSciencePacks-for1_1/locale/en/en.cfg
@@ -151,7 +151,7 @@ moresciencepack-GameProgressionFix=Will remove All MSP packs from technology cos
 
 moresciencepack-unlock-all-packs=Begin the game with the recipes for all 30 MSP science packs enabled without requiring any research to make the packs. This does not extend to the ingredients required to craft the packs, so they won't be able to be crafted until you obtain the necessary ingredients, but this is another method for resolving cyclic-dependency conflicts caused by other mods. Options are nice.
 
-moresciencepack-no-lab-slots=Use with "Remove packs from research cost (Game Progression Fix)" as well as MomoTweaks mod to treat MSP's 30 Packs as Intermediate crafting ingredients for vanilla packs only. Removes slots from labs, and slightly simplifies logistic headache....at a cost of even more complex crafting. DO NOT TOGGLE THIS during a game with active labs or labs containing MSP packs. 
+moresciencepack-no-lab-slots=Use with "Remove packs from research cost (Game Progression Fix)" as well as MomoTweak mod to treat MSP's 30 Packs as Intermediate crafting ingredients for vanilla packs only. Removes slots from labs, and slightly simplifies logistic headache....at a cost of even more complex crafting. DO NOT TOGGLE THIS during a game with active labs or labs containing MSP packs.
 
 moresciencepack-IncreasedModuleCost=Adds MSP packs to the cost of module research (not yet implemented)
 moresciencepack-multiplier=Multiply result_count for ALL MSP packs by this value (1-100). Ignored if omniLib is enabled.

--- a/MoreSciencePacks-for1_1/locale/en/en.cfg
+++ b/MoreSciencePacks-for1_1/locale/en/en.cfg
@@ -151,7 +151,7 @@ moresciencepack-GameProgressionFix=Will remove All MSP packs from technology cos
 
 moresciencepack-unlock-all-packs=Begin the game with the recipes for all 30 MSP science packs enabled without requiring any research to make the packs. This does not extend to the ingredients required to craft the packs, so they won't be able to be crafted until you obtain the necessary ingredients, but this is another method for resolving cyclic-dependency conflicts caused by other mods. Options are nice.
 
-moresciencepack-no-lab-slots=To use it check "Remove packs from research cost (Game Progression Fix)" setting and also make sure you use MomosTweak mod. Then MSP's 30 Packs will be treated as Intermediate crafting ingredients for vanilla science packs only. Removes slots from labs, and slightly simplifies logistic headache....at a cost of even more complex crafting. DO NOT TOGGLE THIS during a game with active labs or labs containing MSP packs.
+moresciencepack-no-lab-slots=To use it check "Remove packs from research cost (Game Progression Fix)" setting and also make sure you use MomosTweak mod. Then MSP's 30 Packs will be treated as Intermediate crafting ingredients for vanilla science packs only (to be specific: for each of 6 "accumulator chips"). Also it removes slots from labs, and slightly simplifies logistic headache....at a cost of even more complex crafting. DO NOT TOGGLE THIS during a game with active labs or labs containing MSP packs.
 
 moresciencepack-IncreasedModuleCost=Adds MSP packs to the cost of module research (not yet implemented)
 moresciencepack-multiplier=Multiply result_count for ALL MSP packs by this value (1-100). Ignored if omniLib is enabled.


### PR DESCRIPTION
Fix usage of 'moresciencepack-no-lab-slots' setting

- it was checking old name of mod 'MomoTweak' instead of new: 'MomosTweak'
- reported by user mlxix at: https://mods.factorio.com/mod/MoreSciencePacks-for1_1/discussion/630619661b836f15b20a2002